### PR TITLE
Use hex string for toString()

### DIFF
--- a/spectra.js
+++ b/spectra.js
@@ -426,8 +426,10 @@
     return (this.red() << 16) | (this.green() << 8) | (this.blue());
   };
   
-  // Use hex string function for toString operations
-  // to allow direct assignment to css properties
+  /**
+   * Use hex string function for toString() operations
+   * to allow direct assignment to CSS properties
+   */
   Spectra.fn.prototype.toString = Spectra.fn.prototype.hex;
 
   /**

--- a/test/tester.js
+++ b/test/tester.js
@@ -54,6 +54,8 @@ describe('Spectra', function() {
       expect(color.rgbaString()).toBe('rgba(68,170,255,1)');
       expect(color.hslString()).toBe('hsl(207,1,0.63)');
       expect(color.hslaString()).toBe('hsla(207,1,0.63,1)');
+      expect(color.toString()).toBe('#44aaff');
+      expect('string conversion ' + color).toBe('string conversion #44aaff');
       expect(color.rgbNumber()).toBe(0x44aaff);
     });
 


### PR DESCRIPTION
Just a quick addition to use hex string representation for a spectra object's toString() method. This allows for direct assignment to css properties, such as:

```
red = Spectra("#FF0000");
document.body.style.backgroundColor = red;
```

The rgba representation may be better, so you don't lose the alpha, but it is not supported in old browsers.
