### PR TITLE
Add multiply, invert and screen methods

### DIFF
--- a/spectra.js
+++ b/spectra.js
@@ -659,6 +659,62 @@
   };
 
   /**
+   * multiply
+   *
+   * @desc Multiplies the color with another. The result is a darker picture (goo.gl/f8Gt5D).
+   * @author Benjamin Fleming (benjamminf)
+   * @since 2014-01-06
+   * @param color (Spectra) - The color to dissolve onto.
+   * @return Spectra instance
+   */
+  Spectra.fn.prototype.multiply = function(color) {
+    if(!(color instanceof Spectra.fn)) {
+      color = new Spectra(color);
+    }
+
+    return new Spectra({
+      r: this.red() * color.red() / 255,
+      g: this.green() * color.green() / 255,
+      b: this.blue() * color.blue() / 255,
+      a: color.alpha()
+    });
+  };
+
+  /**
+   * invert
+   *
+   * @desc Inverts the color.
+   * @author Benjamin Fleming (benjamminf)
+   * @since 2014-01-06
+   * @return Spectra instance
+   */
+  Spectra.fn.prototype.invert = function() {
+    return new Spectra({
+      r: 255 - this.red(),
+      g: 255 - this.green(),
+      b: 255 - this.blue(),
+      a: this.alpha()
+    });
+  };
+
+  /**
+   * screen
+   *
+   * @desc Both colors are inverted, multiplied and inverted again (goo.gl/2kSaQq).
+   * @author Benjamin Fleming (benjamminf)
+   * @since 2014-01-06
+   * @param color (Spectra) - The color to dissolve onto.
+   * @return Spectra instance
+   */
+  Spectra.fn.prototype.screen = function(color) {
+    if(!(color instanceof Spectra.fn)) {
+      color = new Spectra(color);
+    }
+
+    return this.invert().multiply(color.invert()).invert();
+  };
+
+  /**
    * Restores the old value of Spectra and returns the wrapper function.
    */
   Spectra.noConflict = function() {

--- a/test/tester.js
+++ b/test/tester.js
@@ -201,6 +201,45 @@ describe('Spectra', function() {
       expect(harmonies[0].hex()).toEqual('#ff194b');
       expect(harmonies[1].hex()).toEqual('#19ffcd');
     });
+
+    it('Multiply', function() {
+      var multiplied;
+      var color1 = Spectra('#0f7');
+      var color2 = Spectra('#f87');
+
+      // General case
+      multiplied = color1.multiply(color2);
+      expect(multiplied.hex()).toEqual('#008838');
+
+      // Multiplying with Spectra-compatible inputs
+      multiplied = color1.multiply('#f87');
+      expect(multiplied.hex()).toEqual('#008838');
+
+      // Invalid inputs
+      expect(function() {color1.multiply(null)}).toThrow();
+    });
+
+    it('Invert', function() {
+      var inverted = color.invert();
+      expect(inverted.hex()).toEqual('#00e6b4');
+    });
+
+    it('Screen', function() {
+      var screened;
+      var color1 = Spectra('#0f7');
+      var color2 = Spectra('#f87');
+
+      // General case
+      screened = color1.screen(color2);
+      expect(screened.hex()).toEqual('#ffffb6');
+
+      // Multiplying with Spectra-compatible inputs
+      screened = color1.screen('#f87');
+      expect(screened.hex()).toEqual('#ffffb6');
+
+      // Invalid inputs
+      expect(function() {color1.screen(null)}).toThrow();
+    });
   });
 
   describe('Utility functions', function() {


### PR DESCRIPTION
Added the blend modes multiply and screen as well as a method to invert
the color. Test cases provided.

Usage:

``` javascript
Spectra(...).multiply(...);
Spectra(...).screen(...);
Spectra(...).invert();
```
